### PR TITLE
fix(popover): focus outline

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -76,6 +76,7 @@ erd.puml
 erd.svg
 intro_header.txt
 TODO.md
+HOTUPDATE.md
 
 # for LLMs
 llm-context.md

--- a/superset-frontend/src/dashboard/components/FiltersBadge/Styles.tsx
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/Styles.tsx
@@ -118,6 +118,10 @@ export const FiltersDetailsContainer = styled.div`
     overflow-x: hidden;
 
     color: ${theme.colorText};
+    
+    &:focus:not(:focus-visible) {
+      outline: none;
+    }
   `}
 `;
 

--- a/superset-frontend/src/dashboard/components/FiltersBadge/Styles.tsx
+++ b/superset-frontend/src/dashboard/components/FiltersBadge/Styles.tsx
@@ -118,7 +118,7 @@ export const FiltersDetailsContainer = styled.div`
     overflow-x: hidden;
 
     color: ${theme.colorText};
-    
+
     &:focus:not(:focus-visible) {
       outline: none;
     }


### PR DESCRIPTION
### SUMMARY
Removes an unintended browser focus outline from the applied filters popover on dashboards.

The popover content can receive focus, which causes a default blue outline to appear after refreshing a dashboard and hovering over the applied filters badge. This change updates the filters details container and uses `:focus:not(:focus-visible)` so mouse hover does not show the outline while still allowing keyboard focus behavior.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

No outline appears after refreshing the page with applied filters
<img width="1002" height="628" alt="no-outline-after-refresh" src="https://github.com/user-attachments/assets/684d29ce-2815-4021-b968-2cdbe619e3b1" />

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Open a dashboard 
2. Select and apply filters.
2. Refresh the dashboard page.
3. Select or Hover over the applied filters icon on a chart.
4. Confirm the applied filters popover appears without the blue focus outline.
5. Use keyboard navigation to focus the filter badge and confirm keyboard focus behavior is still visible.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes apache/superset#38789
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
