### PR TITLE
add customizable filter names for dynamic titles

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/query/types/Dashboard.ts
+++ b/superset-frontend/packages/superset-ui-core/src/query/types/Dashboard.ts
@@ -69,6 +69,7 @@ export type Filter = {
   defaultDataMask: DataMask;
   id: string; // randomly generated at filter creation
   name: string;
+  titleLabel?: string;
   scope: NativeFilterScope;
   filterType: string;
   targets: Partial<NativeFilterTarget>[];

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/FiltersConfigForm/FiltersConfigForm.tsx
@@ -1007,6 +1007,30 @@ const FiltersConfigForm = (
                     </StyledFormItem>
                   )}
                 </StyledContainer>
+                {!isChartCustomization && (
+                  <StyledRowContainer>
+                    <StyledFormItem
+                      expanded={expanded}
+                      name={['filters', filterId, 'titleLabel']}
+                      label={
+                        <StyledLabel>
+                          {t('Chart title label')}
+                          <InfoTooltip
+                            tooltip={t(
+                              'When set, this label is used instead of the filter name in dynamic chart titles.',
+                            )}
+                          />
+                        </StyledLabel>
+                      }
+                      initialValue={filterToEdit?.titleLabel}
+                    >
+                      <Input
+                        placeholder={t('e.g. West Coast Region')}
+                        onChange={debouncedFormChanged}
+                      />
+                    </StyledFormItem>
+                  </StyledRowContainer>
+                )}
                 {formFilter?.filterType === 'filter_time' && (
                   <FilterTypeInfo expanded={expanded}>
                     {t(`Dashboard time range filters apply to temporal columns defined in

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/transformers/filterTransformer.test.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/transformers/filterTransformer.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { NativeFilterType } from '@superset-ui/core';
+import { transformFilterForSave } from './filterTransformer';
+import { NativeFiltersFormItem } from '../types';
+
+const baseFormItem: NativeFiltersFormItem = {
+  name: 'Test Filter',
+  filterType: 'filter_select',
+  scope: {
+    rootPath: ['ROOT_ID'],
+    excluded: [],
+  },
+  dataset: { value: 1 },
+  column: 'country',
+  controlValues: {},
+  defaultDataMask: {},
+  dependencies: [],
+  type: NativeFilterType.NativeFilter,
+};
+
+test('transformFilterForSave includes titleLabel when set', () => {
+  const formItem: NativeFiltersFormItem = {
+    ...baseFormItem,
+    titleLabel: 'West Coast Region',
+  };
+
+  const result = transformFilterForSave('filter_1', formItem);
+
+  expect(result).toMatchObject({
+    titleLabel: 'West Coast Region',
+  });
+});
+
+test('transformFilterForSave omits titleLabel when not provided', () => {
+  const result = transformFilterForSave('filter_1', baseFormItem);
+
+  expect((result as { titleLabel?: string })?.titleLabel).toBeUndefined();
+});
+
+test('transformFilterForSave treats empty string titleLabel as undefined', () => {
+  const formItem: NativeFiltersFormItem = {
+    ...baseFormItem,
+    titleLabel: '',
+  };
+
+  const result = transformFilterForSave('filter_1', formItem);
+
+  expect((result as { titleLabel?: string })?.titleLabel).toBeUndefined();
+});
+
+test('transformFilterForSave preserves other filter properties when titleLabel is set', () => {
+  const formItem: NativeFiltersFormItem = {
+    ...baseFormItem,
+    titleLabel: 'My Custom Label',
+  };
+
+  const result = transformFilterForSave('filter_1', formItem);
+
+  expect(result).toMatchObject({
+    id: 'filter_1',
+    name: 'Test Filter',
+    filterType: 'filter_select',
+    titleLabel: 'My Custom Label',
+  });
+});

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/transformers/filterTransformer.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/transformers/filterTransformer.ts
@@ -131,6 +131,7 @@ function transformFormInput(
     requiredFirst: formInputs.requiredFirst
       ? Object.values(formInputs.requiredFirst).find(rf => rf)
       : undefined,
+    titleLabel: formInputs.titleLabel || undefined,
   };
 }
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/types.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FiltersConfigModal/types.ts
@@ -32,6 +32,7 @@ import { ReactNode } from 'react';
 export interface NativeFiltersFormItem {
   scope: NativeFilterScope;
   name: string;
+  titleLabel?: string;
   filterType: string;
   dataset: {
     value: number;

--- a/superset-frontend/src/dashboard/components/nativeFilters/selectors.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/selectors.ts
@@ -199,6 +199,7 @@ const getRejectedColumns = (chart: any): Set<string> =>
 export type Indicator = {
   column?: QueryFormColumn;
   name: string;
+  titleLabel?: string;
   value?: any;
   status?: IndicatorStatus;
   path?: string[];

--- a/superset-frontend/src/explore/components/ExploreChartHeader/ExploreChartHeader.test.tsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader/ExploreChartHeader.test.tsx
@@ -1317,4 +1317,94 @@ describe('Additional actions tests', () => {
       getSpy.mockRestore();
     });
   });
+
+  test('uses titleLabel from adhoc filter instead of subject for dynamic title', async () => {
+    const props = createProps({
+      formData: {
+        ...createProps().chart.latestQueryFormData,
+        showDynamicTitle: true,
+        adhoc_filters: [{ subject: 'country', titleLabel: 'West Coast Region' }],
+      },
+      chart: {
+        ...createProps().chart,
+        queriesResponse: null,
+      },
+    });
+
+    render(<ExploreHeader {...props} />, { useRedux: true });
+
+    expect(
+      await screen.findByDisplayValue(
+        'Age distribution of respondents by West Coast Region',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  test('falls back to subject when titleLabel is empty string', async () => {
+    const props = createProps({
+      formData: {
+        ...createProps().chart.latestQueryFormData,
+        showDynamicTitle: true,
+        adhoc_filters: [{ subject: 'country', titleLabel: '' }],
+      },
+      chart: {
+        ...createProps().chart,
+        queriesResponse: null,
+      },
+    });
+
+    render(<ExploreHeader {...props} />, { useRedux: true });
+
+    expect(
+      await screen.findByDisplayValue(
+        'Age distribution of respondents by country',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  test('uses titleLabel from native filter for dynamic title', async () => {
+    const props = createProps({
+      formData: {
+        ...createProps().chart.latestQueryFormData,
+        showDynamicTitle: true,
+        extra_form_data: {
+          filters: [{ col: 'state', op: 'IN', val: ['CA'], titleLabel: 'Pacific States' }],
+        },
+      },
+      chart: {
+        ...createProps().chart,
+        queriesResponse: null,
+      },
+    });
+
+    render(<ExploreHeader {...props} />, { useRedux: true });
+
+    expect(
+      await screen.findByDisplayValue(
+        'Age distribution of respondents by Pacific States',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  test('uses titleLabel over column name when both are present', async () => {
+    const props = createProps({
+      formData: {
+        ...createProps().chart.latestQueryFormData,
+        showDynamicTitle: true,
+        adhoc_filters: [{ column: 'region', titleLabel: 'Sales Region' }],
+      },
+      chart: {
+        ...createProps().chart,
+        queriesResponse: null,
+      },
+    });
+
+    render(<ExploreHeader {...props} />, { useRedux: true });
+
+    expect(
+      await screen.findByDisplayValue(
+        'Age distribution of respondents by Sales Region',
+      ),
+    ).toBeInTheDocument();
+  });
 });

--- a/superset-frontend/src/explore/components/ExploreChartHeader/index.tsx
+++ b/superset-frontend/src/explore/components/ExploreChartHeader/index.tsx
@@ -251,6 +251,12 @@ export const ExploreChartHeader: FC<ExploreChartHeaderProps> = ({
     }
 
     const filterMeta = filter as Record<string, unknown>;
+    if (
+      typeof filterMeta.titleLabel === 'string' &&
+      filterMeta.titleLabel.length > 0
+    ) {
+      return filterMeta.titleLabel;
+    }
     const subject = filterMeta.subject;
     const subjectName =
       typeof subject === 'string'

--- a/superset-frontend/src/explore/components/ExploreViewContainer/ExploreViewContainer.test.tsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/ExploreViewContainer.test.tsx
@@ -1052,3 +1052,71 @@ test('automatic axis title margin adjustment handles both X and Y axis titles be
     jest.restoreAllMocks();
   }
 });
+
+test('prefills SaveModal with titleLabel from adhoc filter when dynamic title is enabled', async () => {
+  const customState = {
+    ...reduxState,
+    explore: {
+      ...reduxState.explore,
+      sliceName: 'Sales Report',
+      controls: {
+        ...reduxState.explore.controls,
+        show_dynamic_title: { value: true },
+        adhoc_filters: {
+          value: [{ subject: 'region', titleLabel: 'West Coast' }],
+        },
+      },
+    },
+    charts: {
+      ...reduxState.charts,
+      1: {
+        ...reduxState.charts[1],
+        queriesResponse: null,
+      },
+    },
+    saveModal: {
+      isVisible: true,
+      dashboards: [],
+      saveModalAlert: null,
+    },
+  };
+
+  renderWithRouter({ initialState: customState });
+
+  const chartNameInput = await screen.findByTestId('new-chart-name');
+  expect(chartNameInput).toHaveValue('Sales Report by West Coast');
+});
+
+test('titleLabel takes precedence over column name in SaveModal prefill', async () => {
+  const customState = {
+    ...reduxState,
+    explore: {
+      ...reduxState.explore,
+      sliceName: 'Revenue Chart',
+      controls: {
+        ...reduxState.explore.controls,
+        show_dynamic_title: { value: true },
+        adhoc_filters: {
+          value: [{ column: 'territory', titleLabel: 'APAC Territory' }],
+        },
+      },
+    },
+    charts: {
+      ...reduxState.charts,
+      1: {
+        ...reduxState.charts[1],
+        queriesResponse: null,
+      },
+    },
+    saveModal: {
+      isVisible: true,
+      dashboards: [],
+      saveModalAlert: null,
+    },
+  };
+
+  renderWithRouter({ initialState: customState });
+
+  const chartNameInput = await screen.findByTestId('new-chart-name');
+  expect(chartNameInput).toHaveValue('Revenue Chart by APAC Territory');
+});

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.tsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.tsx
@@ -320,6 +320,12 @@ function getDisplaySliceTitle(
     }
 
     const filterMeta = filter as Record<string, unknown>;
+    if (
+      typeof filterMeta.titleLabel === 'string' &&
+      filterMeta.titleLabel.length > 0
+    ) {
+      return filterMeta.titleLabel;
+    }
     const subject = filterMeta.subject;
     const subjectName =
       typeof subject === 'string'

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilter/index.ts
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilter/index.ts
@@ -44,6 +44,7 @@ interface AdhocFilterInput {
   deck_slices?: unknown;
   layerFilterScope?: unknown;
   filterOptionName?: string;
+  titleLabel?: string;
   // Allow additional properties for flexibility
   [key: string]: unknown;
 }
@@ -62,6 +63,7 @@ export default class AdhocFilter {
   deck_slices?: unknown;
   layerFilterScope?: unknown;
   filterOptionName: string;
+  titleLabel?: string;
 
   constructor(adhocFilter: AdhocFilterInput) {
     this.expressionType = adhocFilter.expressionType || ExpressionTypes.Simple;
@@ -111,6 +113,8 @@ export default class AdhocFilter {
       `filter_${Math.random().toString(36).substring(2, 15)}_${Math.random()
         .toString(36)
         .substring(2, 15)}`;
+
+    this.titleLabel = adhocFilter.titleLabel as string | undefined;
   }
 
   duplicateWith(nextFields: Partial<AdhocFilterInput>): AdhocFilter {
@@ -129,6 +133,7 @@ export default class AdhocFilter {
       deck_slices: this.deck_slices,
       layerFilterScope: this.layerFilterScope,
       filterOptionName: this.filterOptionName,
+      titleLabel: this.titleLabel,
       ...nextFields,
     };
     return new AdhocFilter(currentFields);
@@ -142,7 +147,8 @@ export default class AdhocFilter {
       adhocFilter.operator === this.operator &&
       adhocFilter.operatorId === this.operatorId &&
       adhocFilter.comparator === this.comparator &&
-      adhocFilter.subject === this.subject
+      adhocFilter.subject === this.subject &&
+      adhocFilter.titleLabel === this.titleLabel
     );
   }
 

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopover/index.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopover/index.tsx
@@ -19,7 +19,7 @@
 import type React from 'react';
 import { createRef, Component, type RefObject } from 'react';
 import { type SupersetTheme } from '@apache-superset/core/theme';
-import { Button, Icons, Select } from '@superset-ui/core/components';
+import { Button, Icons, Input, Select } from '@superset-ui/core/components';
 import { ErrorBoundary } from 'src/components';
 import { SupersetClient } from '@superset-ui/core';
 import { t } from '@apache-superset/core/translation';
@@ -432,6 +432,20 @@ export default class AdhocFilterEditPopover extends Component<
             },
           ]}
         />
+        <div style={{ marginTop: 8 }}>
+          <Input
+            value={this.state.adhocFilter.titleLabel ?? ''}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              this.onAdhocFilterChange(
+                this.state.adhocFilter.duplicateWith({
+                  titleLabel: e.target.value || undefined,
+                }),
+              );
+            }}
+            placeholder={t('Title label (optional)')}
+            maxLength={100}
+          />
+        </div>
         {hasDeckSlices && (
           <LayerSelectContainer>
             <Select

--- a/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopover/index.tsx
+++ b/superset-frontend/src/explore/components/controls/FilterControl/AdhocFilterEditPopover/index.tsx
@@ -433,6 +433,9 @@ export default class AdhocFilterEditPopover extends Component<
           ]}
         />
         <div style={{ marginTop: 8 }}>
+          <div style={{ marginBottom: 4, fontSize: 12 }}>
+            {t('Custom filter name')}
+          </div>
           <Input
             value={this.state.adhocFilter.titleLabel ?? ''}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
@@ -442,7 +445,7 @@ export default class AdhocFilterEditPopover extends Component<
                 }),
               );
             }}
-            placeholder={t('Title label (optional)')}
+            placeholder={t('Filter name (optional)')}
             maxLength={100}
           />
         </div>


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
<img width="990" height="990" alt="image" src="https://github.com/user-attachments/assets/9e72fde4-9620-42bc-b9e8-8a1ed31ff273" />

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

1. Click Charts in the top navigation
2. Select a chart of the type Treemap
3. Click the Customize tab
4. Click the Show dynamic chart title checkbox
5. Observe the list of active filters is appended to the chart title
6. Click the 'Data' tab
7. Add or remove filters from the Filters list
8. Select a filter to customize
9. Update the name of the filter
10. Observe the chart title is updated to reflect the updated filter title
11. Click the Save button
12. Verify the Chart name field includes the list of active filters with custom name
13. Click the Save button
14. Click Charts from the top navigation
15. Verify the dynamic chart title and custom name persisted

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [X] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [X] Introduces new feature or API
- [ ] Removes existing feature or API
